### PR TITLE
Fixed issue that the parent palette was not buffered for multiple inheritance

### DIFF
--- a/system/modules/metapalettes/MetaPalettes.php
+++ b/system/modules/metapalettes/MetaPalettes.php
@@ -289,7 +289,7 @@ class MetaPalettes
 	 * @param string $strTable
 	 * @param string $strPalette
 	 * @param array $arrMeta
-	 * @return array
+	 * @return void
 	 */
 	public function extendPalette($strTable, &$strPalette, array &$arrMeta)
 	{
@@ -411,6 +411,8 @@ class MetaPalettes
 			}
 
 			$arrMeta = $arrBaseMeta;
+			// keep result for derived palettes to use.
+			$GLOBALS['TL_DCA'][$strTable]['metapalettes'][$strPalette] = $arrMeta;
 		}
 	}
 


### PR DESCRIPTION
Now you can properly extend from palettes that are also extended.
i.e.:

``` php
    'metapalettes' => array
    (
        '_base_' => array
        (
            'sect1' => array('field1')
        ),
        '_simple_ extends _base_' => array
        (
            '+sect1' => array('field2 after field1')
        ),
        '_advanced_ extends _simple_' => array
        (
            '+sect1' => array('field3 after field2')
        )
    )
```

This was not possible before as the MetaPalette tried to fetch an undefined index (the "parent" palette).
