### PR TITLE
Added onload_callback in generateSubSelectPalettes()

### DIFF
--- a/system/modules/metapalettes/MetaPalettes.php
+++ b/system/modules/metapalettes/MetaPalettes.php
@@ -476,7 +476,9 @@ class MetaPalettes extends System
 							}
 						}
 
-						if (isset($GLOBALS['TL_DCA'][$strTable]['fields'][$strSelector]['load_callback'])
+						// call onload callback if the value is not result of a submit.
+						if ((Input::getInstance()->post('FORM_SUBMIT') != $strTable)
+						&& isset($GLOBALS['TL_DCA'][$strTable]['fields'][$strSelector]['load_callback'])
 						&& is_array($GLOBALS['TL_DCA'][$strTable]['fields'][$strSelector]['load_callback']))
 						{
 							foreach ($GLOBALS['TL_DCA'][$strTable]['fields'][$strSelector]['load_callback'] as $callback)


### PR DESCRIPTION
This is needed as otherwise we are comparing the native database content (i.e. an numeric id) against a referenced array (lookup map) that get's converted via onload and onsave callbacks.
