### PR TITLE
Removed an empty check that rendered palette extending useless.

### DIFF
--- a/src/system/modules/metapalettes/MetaPalettes.php
+++ b/src/system/modules/metapalettes/MetaPalettes.php
@@ -309,7 +309,7 @@ class MetaPalettes extends System
 	 */
 	public function extendPalette($strTable, &$strPalette, array &$arrMeta)
 	{
-		if ((!empty($arrMeta)) && preg_match('#^(\w+) extends (\w+)$#', $strPalette, $arrMatch)) {
+		if (preg_match('#^(\w+) extends (\w+)$#', $strPalette, $arrMatch)) {
 			if (!is_array($GLOBALS['TL_DCA'][$strTable]['metapalettes'][$arrMatch[2]]))
 			{
 				return;


### PR DESCRIPTION
Don't know how this slipped in the last commit, but this check made extending impossible.
