### PR TITLE
Add support for sub select palettes mentioning legend names.

### DIFF
--- a/src/MetaPalettesBuilder.php
+++ b/src/MetaPalettesBuilder.php
@@ -311,6 +311,14 @@ class MetaPalettesBuilder extends DcaReadingDataDefinitionBuilder
 				$properties = array();
 
 				foreach ($propertyNames as $propertyName) {
+
+					// Check if it is a valid property name.
+					if (!is_string($propertyName)) {
+						throw new InvalidArgumentException(
+							'Invalid property name in sub palette: ' . var_export($propertyName, true)
+						);
+					}
+
 					$property = new Property($propertyName);
 					$property->setVisibleCondition(new PropertyTrueCondition($selector));
 					$properties[] = $property;


### PR DESCRIPTION
This PR introduces the support of sub select palettes like:

```
'metasubselectpalettes' => array(
    'field_two' => array(
        'value' => array(
            'legend_name_1' => array('field_three'),
            'legend_name_2' => array('field_four')
        )
    )
)
```

This support is present in MetaPalettes.php but was forgotten in the Builder.

This PR fixes some minor issues along the way (see commit messages).
