### PR TITLE
Recalculate the palette condition when deriving from default palette.

### DIFF
--- a/src/MetaPalettesBuilder.php
+++ b/src/MetaPalettesBuilder.php
@@ -120,10 +120,8 @@ class MetaPalettesBuilder extends DcaReadingDataDefinitionBuilder
 						throw new RuntimeException('Parent palette ' . $parentSelector . ' does not exists');
 					}
 
-					// if the parent is the default palette, we MUST NOT retain the DefaultPaletteCondition.
-					if ($palette->getCondition() instanceof DefaultPaletteCondition) {
-						$palette->setCondition($parser->createPaletteCondition($selector, $selectorFieldNames));
-					}
+					// We MUST NOT retain the DefaultPaletteCondition.
+					$palette->setCondition($parser->createPaletteCondition($selector, $selectorFieldNames));
 
 					$extended = true;
 				}


### PR DESCRIPTION
Otherwise we will end up with multiple default palettes rendering DCG useless as it will always have more than one matching palette.

Depends on PR #16 #17 #18 so merge them first.
