### PR TITLE
Add a missing parameter.

### DIFF
--- a/src/MetaPalettesBuilder.php
+++ b/src/MetaPalettesBuilder.php
@@ -47,7 +47,7 @@ class MetaPalettesBuilder extends DcaReadingDataDefinitionBuilder
 		ContainerInterface $container,
 		BuildDataDefinitionEvent $event
 	) {
-		if (!$this->loadDca($container->getName())) {
+		if (!$this->loadDca($container->getName(), $event->getDispatcher())) {
 			return;
 		}
 


### PR DESCRIPTION
The loadDCA function needs two parameters. The second parameter must be a object which implements the interface EventDispatcherInterface.
