### PR TITLE
Hotfix for conflicts of DcGeneral and meta palettes

### DIFF
--- a/src/MetaPalettes.php
+++ b/src/MetaPalettes.php
@@ -486,9 +486,12 @@ class MetaPalettes extends System
 						// therefore no instanceof check, do NOT(!) try to load via post if DC_General is in use, as it has
 						// already updated the current model.
 						if (method_exists($dc, 'getEnvironment')) {
-							$objModel = $dc->getEnvironment()->getCurrentModel();
-							if ($objModel) {
-								$strValue = $objModel->getProperty($strSelector);
+							$objEnvironent = $dc->getEnvironment();
+							if (method_exists($objEnvironent, 'getCurrentModel')) {
+								$objModel = $dc->getEnvironment()->getCurrentModel();
+								if ($objModel) {
+									$strValue = $objModel->getProperty($strSelector);
+								}
 							}
 						}
 						else if (method_exists($dc, 'getCurrentModel')) {


### PR DESCRIPTION
Avoid model updating because newes dc general does not provide a `getCurrentModel` method anymore:
[EnvironmentInterface](https://github.com/contao-community-alliance/dc-general/blob/develop/src/ContaoCommunityAlliance/DcGeneral/EnvironmentInterface.php)