### PR TITLE
Fix model call

### DIFF
--- a/.composer-require-checker.json
+++ b/.composer-require-checker.json
@@ -9,18 +9,19 @@
     "Contao\\ManagerPlugin\\Config\\ContainerBuilder",
     "Contao\\ManagerPlugin\\Config\\ExtensionPluginInterface",
     "Contao\\ManagerPlugin\\Dependency\\DependentPluginInterface",
-    "ContaoCommunityAlliance\\DcGeneral\\Factory\\Event\\BuildDataDefinitionEvent",
-    "ContaoCommunityAlliance\\DcGeneral\\DataDefinition\\Definition\\PalettesDefinitionInterface",
-    "ContaoCommunityAlliance\\DcGeneral\\DataDefinition\\Definition\\DefaultPalettesDefinition",
+    "ContaoCommunityAlliance\\DcGeneral\\Contao\\Compatibility\\DcCompat",
     "ContaoCommunityAlliance\\DcGeneral\\Contao\\Dca\\Palette\\LegacyPalettesParser",
+    "ContaoCommunityAlliance\\DcGeneral\\DataDefinition\\Definition\\DefaultPalettesDefinition",
+    "ContaoCommunityAlliance\\DcGeneral\\DataDefinition\\Definition\\PalettesDefinitionInterface",
+    "ContaoCommunityAlliance\\DcGeneral\\DataDefinition\\Palette\\Condition\\Property\\NotCondition",
     "ContaoCommunityAlliance\\DcGeneral\\DataDefinition\\Palette\\Condition\\Property\\PropertyConditionChain",
     "ContaoCommunityAlliance\\DcGeneral\\DataDefinition\\Palette\\Condition\\Property\\PropertyTrueCondition",
-    "ContaoCommunityAlliance\\DcGeneral\\DataDefinition\\Palette\\Condition\\Property\\PropertyVisibleCondition",
-    "ContaoCommunityAlliance\\DcGeneral\\DataDefinition\\Palette\\Property",
     "ContaoCommunityAlliance\\DcGeneral\\DataDefinition\\Palette\\Condition\\Property\\PropertyValueCondition",
-    "ContaoCommunityAlliance\\DcGeneral\\DataDefinition\\Palette\\Condition\\Property\\NotCondition",
-    "ContaoCommunityAlliance\\DcGeneral\\DataDefinition\\Palette\\Palette",
+    "ContaoCommunityAlliance\\DcGeneral\\DataDefinition\\Palette\\Condition\\Property\\PropertyVisibleCondition",
     "ContaoCommunityAlliance\\DcGeneral\\DataDefinition\\Palette\\Legend",
-    "ContaoCommunityAlliance\\DcGeneral\\DataDefinition\\Palette\\LegendInterface"
+    "ContaoCommunityAlliance\\DcGeneral\\DataDefinition\\Palette\\LegendInterface",
+    "ContaoCommunityAlliance\\DcGeneral\\DataDefinition\\Palette\\Palette",
+    "ContaoCommunityAlliance\\DcGeneral\\DataDefinition\\Palette\\Property",
+    "ContaoCommunityAlliance\\DcGeneral\\Factory\\Event\\BuildDataDefinitionEvent"
   ]
 }

--- a/src/Listener/SubSelectPalettesListener.php
+++ b/src/Listener/SubSelectPalettesListener.php
@@ -1,16 +1,24 @@
 <?php
 
 /**
- * MetaPalettes for the Contao Open Source CMS
+ * This file is part of contao-community-alliance/meta-palettes.
  *
- * @package   MetaPalettes
- * @author    David Molineus <david.molineus@netzmacht.de>
- * @author    Christopher Bölter <christopher@boelter.eu>
- * @author    Sven Baumann <baumann.sv@gmail.com>
- * @copyright 2013-2014 bit3 UG
- * @copyright 2015-2018 Contao Community Alliance.
- * @license   LGPL-3.0+ https://github.com/contao-community-alliance/meta-palettes/license
- * @link      https://github.com/bit3/contao-meta-palettes
+ * (c) 2015-2021 Contao Community Alliance.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * This project is provided in good faith and hope to be usable by anyone.
+ *
+ * @package    contao-community-alliance/meta-palettes
+ * @author     Tristan Lins <tristan.lins@bit3.de>
+ * @author     David Molineus <david.molineus@netzmacht.de>
+ * @author     Christopher Bölter <christopher@boelter.eu>
+ * @author     Sven Baumann <baumann.sv@gmail.com>
+ * @author     Ingolf Steinhardt <info@e-spin.de>
+ * @copyright  2015-2021 Contao Community Alliance.
+ * @license    https://github.com/contao-community-alliance/meta-palettes/license LGPL-3.0-or-later
+ * @filesource
  */
 
 namespace ContaoCommunityAlliance\MetaPalettes\Listener;
@@ -155,6 +163,11 @@ class SubSelectPalettesListener
     private function getValue($dataContainer, $strTable, $strSelector)
     {
         $strValue = null;
+
+        if (method_exists($dataContainer, 'getModel')) {
+            $objModel = $dataContainer->getModel();
+            return $this->getValueFromDcGeneralModel($objModel, $strSelector);
+        }
 
         // try getting getCurrentModel value, provided by DC_General which is not neccessarily installed
         // therefore no instanceof check, do NOT(!) try to load via post if DC_General is in use, as it

--- a/src/Listener/SubSelectPalettesListener.php
+++ b/src/Listener/SubSelectPalettesListener.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of contao-community-alliance/meta-palettes.
  *
- * (c) 2015-2021 Contao Community Alliance.
+ * (c) 2015-2022 Contao Community Alliance.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -16,7 +16,7 @@
  * @author     Christopher Bölter <christopher@boelter.eu>
  * @author     Sven Baumann <baumann.sv@gmail.com>
  * @author     Ingolf Steinhardt <info@e-spin.de>
- * @copyright  2015-2021 Contao Community Alliance.
+ * @copyright  2015-2022 Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/meta-palettes/license LGPL-3.0-or-later
  * @filesource
  */
@@ -29,6 +29,7 @@ use Contao\DC_File;
 use Contao\DC_Table;
 use Contao\Input;
 use Contao\System;
+use ContaoCommunityAlliance\DcGeneral\Contao\Compatibility\DcCompat;
 use ContaoCommunityAlliance\DcGeneral\Data\ModelInterface;
 use ContaoCommunityAlliance\MetaPalettes\MetaPalettes;
 use Doctrine\DBAL\Connection;
@@ -164,21 +165,8 @@ class SubSelectPalettesListener
     {
         $strValue = null;
 
-        if (method_exists($dataContainer, 'getModel')) {
+        if ($dataContainer instanceof DcCompat) {
             $objModel = $dataContainer->getModel();
-            return $this->getValueFromDcGeneralModel($objModel, $strSelector);
-        }
-
-        // try getting getCurrentModel value, provided by DC_General which is not neccessarily installed
-        // therefore no instanceof check, do NOT(!) try to load via post if DC_General is in use, as it
-        // has already updated the current model.
-        if (method_exists($dataContainer, 'getEnvironment')) {
-            $objModel = $dataContainer->getEnvironment()->getCurrentModel();
-            return $this->getValueFromDcGeneralModel($objModel, $strSelector);
-        }
-
-        if (method_exists($dataContainer, 'getCurrentModel')) {
-            $objModel = $dataContainer->getCurrentModel();
             return $this->getValueFromDcGeneralModel($objModel, $strSelector);
         }
 

--- a/src/Listener/SubSelectPalettesListener.php
+++ b/src/Listener/SubSelectPalettesListener.php
@@ -16,6 +16,7 @@
  * @author     Christopher Bölter <christopher@boelter.eu>
  * @author     Sven Baumann <baumann.sv@gmail.com>
  * @author     Ingolf Steinhardt <info@e-spin.de>
+ * @copyright  2013-2014 bit3 UG
  * @copyright  2015-2022 Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/meta-palettes/license LGPL-3.0-or-later
  * @filesource


### PR DESCRIPTION
Fix model call

Wenn "hofff_consent_bridge_consent_tool" installiert ist und bei MM Attribute Select mit Popup-Widget ausgewählt ist, kommt eine Fehlermeldung:

```
Symfony\Component\ErrorHandler\Error\UndefinedMethodError:
Attempted to call an undefined method named "getCurrentModel" of class "ContaoCommunityAlliance\DcGeneral\DefaultEnvironment".

  at vendor/contao-community-alliance/meta-palettes/src/Listener/SubSelectPalettesListener.php:163
  at ContaoCommunityAlliance\MetaPalettes\Listener\SubSelectPalettesListener->getValue(object(DcCompat), 'tl_page', 'hofff_consent_bridge_consent_tool')
     (vendor/contao-community-alliance/meta-palettes/src/Listener/SubSelectPalettesListener.php:88)
  at ContaoCommunityAlliance\MetaPalettes\Listener\SubSelectPalettesListener->onLoad(object(DcCompat))
     (vendor/contao-community-alliance/dc-general/src/Contao/Callback/Callbacks.php:75)
  at ContaoCommunityAlliance\DcGeneral\Contao\Callback\Callbacks::callArgs(array(object(SubSelectPalettesListener), 'onLoad'), array(object(DcCompat)))
     (vendor/contao-community-alliance/dc-general/src/Contao/Callback/AbstractCallbackListener.php:117)
  at ContaoCommunityAlliance\DcGeneral\Contao\Callback\AbstractCallbackListener->__invoke(object(CreateDcGeneralEvent), 'dc-general.factory.create-dc-general', object(TraceableEventDispatcher))
```

habe mir das mit @baumannsven angesehen... das kann wohl weg - `getCurrentModel()` haben wir nicht gefunden

```
        // try getting getCurrentModel value, provided by DC_General which is not neccessarily installed
        // therefore no instanceof check, do NOT(!) try to load via post if DC_General is in use, as it
        // has already updated the current model.
        if (method_exists($dataContainer, 'getEnvironment')) {
            $objModel = $dataContainer->getEnvironment()->getCurrentModel();
            return $this->getValueFromDcGeneralModel($objModel, $strSelector);
        }

        if (method_exists($dataContainer, 'getCurrentModel')) {
            $objModel = $dataContainer->getCurrentModel();
            return $this->getValueFromDcGeneralModel($objModel, $strSelector);
        }
```
