### PR TITLE
Trust the release key of PHP_CodeSniffer 4.0.4

### DIFF
--- a/.phpcq.yaml.dist
+++ b/.phpcq.yaml.dist
@@ -47,6 +47,7 @@ phpcq:
     # PHP_CodeSniffer
     - 31C7E470E2138192
     - 97B02DD8E5071466
+    - 96E91A992CF22FF4
     # Composer normalize
     - C00543248C87FB13
     # PHPMD


### PR DESCRIPTION
The phars are signed with the release key of PHPCSStandards (96E91A992CF22FF4, Juliette Reinders Folmer <juliette@phpcodesniffer.com>). Without it among the trusted keys phpcq stops with an interactive trust prompt when installing the tool and aborts.